### PR TITLE
2021-03-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@
 - Portfolio - Template 설계 분리
 - Template dto, service, reposritoy, controller 테스트 완료
 
+3.1(2021-03-02)
+- TemplateTwo에 대한 read구현(fetch join 적용)
+- Portfolio에 Member를 set할 때 세션 값을 가져오는 역할 변경
+
 
 ## todo 리스트
 

--- a/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
+++ b/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.appeal.api.advice;
 
 import com.appeal.api.advice.dto.ErrorResponse;
-import com.appeal.exception.DuplicateEmailException;
-import com.appeal.exception.FailImageUploadException;
-import com.appeal.exception.NoSupportDtoException;
-import com.appeal.exception.UnexpectedMethodArgumentNullPointerException;
+import com.appeal.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -49,9 +46,18 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnexpectedMethodArgumentNullPointerException.class)
-    public ResponseEntity<ErrorResponse> UnexpectedMethodArgumentNullPointerException(UnexpectedMethodArgumentNullPointerException exception){
+    public ResponseEntity<ErrorResponse> unexpectedMethodArgumentNullPointerException(UnexpectedMethodArgumentNullPointerException exception){
         ErrorResponse body = new ErrorResponse(exception.getMessage());
         log.info("나올 수 없는 널포인터 익셉션: {}", exception.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(body)
+                ;
+    }
+
+    @ExceptionHandler(NoPortfolioFoundException.class)
+    public ResponseEntity<ErrorResponse> noPortfolioFoundExceptoin(NoPortfolioFoundException exception){
+        ErrorResponse body = new ErrorResponse((exception.getMessage()));
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(body)

--- a/appeal-api/src/main/java/com/appeal/api/common/dto/portfolio/TemplateDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/common/dto/portfolio/TemplateDto.java
@@ -1,4 +1,0 @@
-package com.appeal.api.common.dto.portfolio;
-
-public interface TemplateDto {
-}

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/controller/TemplateController.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/controller/TemplateController.java
@@ -1,10 +1,12 @@
 package com.appeal.api.portfolio.controller;
 
-import com.appeal.api.common.dto.portfolio.TemplateDto;
+import com.appeal.api.portfolio.dto.TemplateDto;
 import com.appeal.api.portfolio.service.TemplateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.validation.Valid;
@@ -22,6 +24,14 @@ public class TemplateController<D extends TemplateDto, S extends TemplateService
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(templateService.createTemplate(dto))
+                ;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TemplateDto> getTemplateById(@PathVariable("id") Long id){
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(templateService.getTemplateById(id))
                 ;
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/controller/TemplateTwoController.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/controller/TemplateTwoController.java
@@ -1,6 +1,6 @@
 package com.appeal.api.portfolio.controller;
 
-import com.appeal.api.common.dto.portfolio.TemplateTwoFileDto;
+import com.appeal.api.portfolio.dto.TemplateTwoFileDto;
 import com.appeal.api.portfolio.service.TemplateTwoService;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/domain/Portfolio.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/domain/Portfolio.java
@@ -1,10 +1,9 @@
 package com.appeal.api.portfolio.domain;
 
 import com.appeal.api.common.BaseTimeInfo;
-import com.appeal.api.common.dto.portfolio.PortfolioDto;
+import com.appeal.api.portfolio.dto.PortfolioDto;
 import com.appeal.api.member.domain.Member;
 import lombok.*;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.persistence.*;
 
@@ -26,10 +25,10 @@ public class Portfolio extends BaseTimeInfo {
     private String intro;
     private String templateType;
 
-    public static Portfolio createPortfolio(PortfolioDto portfolio, String templateType) {
+    public static Portfolio createPortfolio(PortfolioDto portfolio, String templateType, Member member) {
         return
                 Portfolio.builder()
-                .member((Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+                .member(member)
                 .intro(portfolio.getIntro())
                 .name(portfolio.getName())
                 .skill(portfolio.getSkill())

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwo.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwo.java
@@ -1,6 +1,7 @@
 package com.appeal.api.portfolio.domain;
 
-import com.appeal.api.common.dto.portfolio.TemplateTwoDto;
+import com.appeal.api.portfolio.dto.TemplateTwoDto;
+import com.appeal.api.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,9 +29,9 @@ public class TemplateTwo {
     @OneToMany(mappedBy = "templateTwo", cascade = CascadeType.ALL)
     private List<TemplateTwoCareer> careers = new ArrayList<>();
 
-    public static TemplateTwo createTemplateTwo(TemplateTwoDto templateTwoDto) {
+    public static TemplateTwo createTemplateTwo(TemplateTwoDto templateTwoDto, Member member) {
                 TemplateTwo templateTwo = new TemplateTwo();
-                templateTwo.portfolio = Portfolio.createPortfolio(templateTwoDto.getPortfolio(), getTemplateType());
+                templateTwo.portfolio = Portfolio.createPortfolio(templateTwoDto.getPortfolio(), getTemplateType(), member);
                 templateTwoDto.getProjects().forEach(project->{
                     templateTwo.projects.add(TemplateTwoProject.createTemplateTwoProject(project, templateTwo));
                 });

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwoCareer.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwoCareer.java
@@ -1,6 +1,6 @@
 package com.appeal.api.portfolio.domain;
 
-import com.appeal.api.common.dto.portfolio.TemplateTwoCareerDto;
+import com.appeal.api.portfolio.dto.TemplateTwoCareerDto;
 import lombok.*;
 
 import javax.persistence.*;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwoProject.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/domain/TemplateTwoProject.java
@@ -1,6 +1,6 @@
 package com.appeal.api.portfolio.domain;
 
-import com.appeal.api.common.dto.portfolio.TemplateTwoProjectDto;
+import com.appeal.api.portfolio.dto.TemplateTwoProjectDto;
 import lombok.*;
 
 import javax.persistence.*;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/PortfolioDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/PortfolioDto.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/PortfolioFileDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/PortfolioFileDto.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateDto.java
@@ -1,0 +1,4 @@
+package com.appeal.api.portfolio.dto;
+
+public interface TemplateDto {
+}

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoCareerDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoCareerDto.java
@@ -1,8 +1,8 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 import lombok.*;
 
-@Getter @Setter
+@Getter @Setter @Builder
 public class TemplateTwoCareerDto {
     private String title;
     private String date;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoDto.java
@@ -1,5 +1,9 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
+import com.appeal.api.portfolio.domain.Portfolio;
+import com.appeal.api.portfolio.domain.TemplateTwo;
+import com.appeal.api.portfolio.domain.TemplateTwoCareer;
+import com.appeal.api.portfolio.domain.TemplateTwoProject;
 import com.appeal.exception.UnexpectedMethodArgumentNullPointerException;
 import com.appeal.service.AwsS3Service;
 import lombok.AccessLevel;
@@ -12,7 +16,7 @@ import java.util.List;
 
 @Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
-public class TemplateTwoDto {
+public class TemplateTwoDto implements TemplateDto{
     private PortfolioDto portfolio;
     private List<TemplateTwoProjectDto> projects = new ArrayList<>();
     private List<TemplateTwoCareerDto> careers = new ArrayList<>();
@@ -27,6 +31,48 @@ public class TemplateTwoDto {
             throw new UnexpectedMethodArgumentNullPointerException("Null이 나올 수 없는 상황입니다");
         }
         return templateTwoDto;
+    }
+
+    // project에 대한, career에 대한 쿼리 두방이 호출될 것. 한 템플릿 쿼리를 위해 총 3방의 쿼리 호출
+    public static TemplateTwoDto convertDomainToDto(TemplateTwo templateTwo) {
+        TemplateTwoDto templateTwoDto = new TemplateTwoDto();
+        templateTwoDto.convertPortfolioToPortfolioDto(templateTwo.getPortfolio());
+        templateTwoDto.convertTemplateTwoCareerToTemplateTwoCareerDto(templateTwo.getCareers());
+        return null;
+    }
+
+    private void convertTemplateTwoCareerToTemplateTwoCareerDto(List<TemplateTwoCareer> careers){
+        careers.forEach(career->{
+            this.getCareers().add(TemplateTwoCareerDto.builder()
+            .date(career.getDate())
+            .title(career.getTitle())
+            .intro(career.getIntro())
+            .position(career.getPosition())
+            .build())
+            ;
+        });
+    }
+
+    private void convertTemplateTwoProjectToTemplateTwoProjectDto(List<TemplateTwoProject> projects){
+        projects.forEach(project->{
+            this.getProjects().add(TemplateTwoProjectDto.builder()
+                    .name(project.getName())
+                    .role(project.getRole())
+                    .intro(project.getIntro())
+                   .thumbnail(project.getThumbnail())
+                   .build()
+            );
+        });
+    }
+    private void convertPortfolioToPortfolioDto(Portfolio portfolio){
+        this.portfolio = PortfolioDto.builder()
+                .thumbnail(portfolio.getThumbnail())
+                .intro(portfolio.getIntro())
+                .name(portfolio.getName())
+                .skill(portfolio.getSkill())
+                .title(portfolio.getTitle())
+                .build()
+                ;
     }
 
     private void convertProjectFileDtotoStringUrlDto(TemplateTwoFileDto dto, AwsS3Service s3Service) {

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoFileDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoFileDto.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 import lombok.*;
 

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoProjectDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoProjectDto.java
@@ -1,7 +1,6 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoProjectFileDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/dto/TemplateTwoProjectFileDto.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.portfolio.dto;
 
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/repository/TemplateTwoRepository.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/repository/TemplateTwoRepository.java
@@ -1,7 +1,16 @@
 package com.appeal.api.portfolio.repository;
 
 import com.appeal.api.portfolio.domain.TemplateTwo;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface TemplateTwoRepository extends JpaRepository<TemplateTwo, Long> {
+
+    @Query("select t " +
+            "from TemplateTwo as t " +
+            "join fetch t.portfolio")
+    Optional<TemplateTwo> findById(Long id);
 }

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateService.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateService.java
@@ -1,8 +1,9 @@
 package com.appeal.api.portfolio.service;
 
-import com.appeal.api.common.dto.portfolio.TemplateDto;
-import org.springframework.stereotype.Service;
+import com.appeal.api.portfolio.dto.TemplateDto;
 
 public interface TemplateService {
     Long createTemplate(TemplateDto dto);
+
+    TemplateDto getTemplateById(Long id);
 }

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateTwoService.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateTwoService.java
@@ -1,12 +1,15 @@
 package com.appeal.api.portfolio.service;
 
-import com.appeal.api.common.dto.portfolio.TemplateDto;
-import com.appeal.api.common.dto.portfolio.TemplateTwoDto;
-import com.appeal.api.common.dto.portfolio.TemplateTwoFileDto;
+import com.appeal.api.portfolio.dto.TemplateDto;
+import com.appeal.api.portfolio.dto.TemplateTwoDto;
+import com.appeal.api.portfolio.dto.TemplateTwoFileDto;
+import com.appeal.api.member.domain.Member;
 import com.appeal.api.portfolio.domain.TemplateTwo;
 import com.appeal.api.portfolio.repository.TemplateTwoRepository;
+import com.appeal.exception.NoPortfolioFoundException;
 import com.appeal.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +21,23 @@ public class TemplateTwoService implements TemplateService{
     private final AwsS3Service s3Service;   // 보기 너무 안 좋다
     private final TemplateTwoRepository templateTwoRepository;
 
+    /**
+     * Member는 생성정보를 통해 Portfolio에 반드시 들어가야 되는데 언제 넣어주는 게 정석일까?
+     * 일단 도메인에서 시큐리티 컨텍스트를 직접 호출하는 건 테스트를 통해 도메인과 외부 기술의 강한 결합 때문에 별로라는 거 인식
+     * 일단 잡다구리한 서비스 계층에서 궂은 일을 도맡아 해주는 걸로 가자
+     */
     @Override
     public Long createTemplate(TemplateDto dto) {
         TemplateTwoDto templateTwoDto = TemplateTwoDto.convertFileDtoToStringUrl((TemplateTwoFileDto) dto, s3Service);
-        TemplateTwo templateTwo = TemplateTwo.createTemplateTwo(templateTwoDto);
+        Member member = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        TemplateTwo templateTwo = TemplateTwo.createTemplateTwo(templateTwoDto, member);
         templateTwoRepository.save(templateTwo);
         return templateTwo.getId();
+    }
+
+    @Override
+    public TemplateDto getTemplateById(Long id) {
+        TemplateTwo templateTwo = templateTwoRepository.findById(id).orElseThrow(NoPortfolioFoundException::new);
+        return TemplateTwoDto.convertDomainToDto(templateTwo);
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/security/config/SecurityConfig.java
+++ b/appeal-api/src/main/java/com/appeal/api/security/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.appeal.api.security.filter.CustomUsernamePasswordAuthenticationFilter
 import com.appeal.api.security.handler.CustomAuthenticationFailureHandler;
 import com.appeal.api.security.handler.CustomAuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -38,6 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .authorizeRequests()
                 .antMatchers("/signup/**", "/signin").permitAll()
+                .antMatchers(HttpMethod.GET, "/template**/*", "/portfolio/**").permitAll()
                 .antMatchers("/**").hasRole("USER")
                 .anyRequest().authenticated()
         ;

--- a/appeal-api/src/test/java/com/appeal/api/common/dto/portfolio/TemplateTwoDtoTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/common/dto/portfolio/TemplateTwoDtoTest.java
@@ -1,11 +1,13 @@
 package com.appeal.api.common.dto.portfolio;
 
+import com.appeal.api.portfolio.dto.PortfolioFileDto;
+import com.appeal.api.portfolio.dto.TemplateTwoDto;
+import com.appeal.api.portfolio.dto.TemplateTwoFileDto;
 import com.appeal.exception.UnexpectedMethodArgumentNullPointerException;
 import com.appeal.service.AwsS3Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/appeal-api/src/test/java/com/appeal/api/portfolio/repository/TemplateTwoRepositoryTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/portfolio/repository/TemplateTwoRepositoryTest.java
@@ -1,7 +1,12 @@
 package com.appeal.api.portfolio.repository;
 
-import com.appeal.api.common.dto.portfolio.PortfolioDto;
-import com.appeal.api.common.dto.portfolio.TemplateTwoDto;
+import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.portfolio.dto.PortfolioDto;
+import com.appeal.api.portfolio.dto.TemplateTwoCareerDto;
+import com.appeal.api.portfolio.dto.TemplateTwoDto;
+import com.appeal.api.portfolio.dto.TemplateTwoProjectDto;
+import com.appeal.api.member.domain.Member;
+import com.appeal.api.member.repository.MemberRepository;
 import com.appeal.api.portfolio.domain.Portfolio;
 import com.appeal.api.portfolio.domain.TemplateTwo;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,12 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import javax.persistence.EntityManager;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class TemplateTwoRepositoryTest {
 
     @Autowired TemplateTwoRepository templateTwoRepository;
+    @Autowired
+    EntityManager em;
+    @Autowired
+    MemberRepository memberRepository;
     TemplateTwo templateTwo;
     TemplateTwoDto templateTwoDto;
 
@@ -23,16 +34,33 @@ class TemplateTwoRepositoryTest {
     void before(){
         templateTwoDto = new TemplateTwoDto();
         templateTwoDto.setPortfolio(new PortfolioDto());
-        templateTwo = TemplateTwo.createTemplateTwo(templateTwoDto);
+        templateTwoDto.getProjects().add(TemplateTwoProjectDto.builder().build());
+        templateTwoDto.getProjects().add(TemplateTwoProjectDto.builder().build());
+        templateTwoDto.getProjects().add(TemplateTwoProjectDto.builder().build());
+        templateTwoDto.getCareers().add(TemplateTwoCareerDto.builder().build());
+        Member member = Member.createMember(new SignUpDto());
+        memberRepository.save(member);
+        templateTwo = TemplateTwo.createTemplateTwo(templateTwoDto, member);
     }
 
     @Test
-    @DisplayName("TemplateTwo를통해 Portfolio를 저장할 때 PK가 잘 저장되는지")
+    @DisplayName("TemplateTwo를 통해 Portfolio를 저장할 때 PK가 잘 저장되는지")
     public void successCreate() throws Exception{
         //given
         templateTwoRepository.save(templateTwo);
         Portfolio portfolio = templateTwo.getPortfolio();
         //then
         assertEquals(portfolio.getId(), templateTwo.getId());
+    }
+
+    @Test
+    @DisplayName("페치조인 테스트")
+    public void findById() throws Exception{
+        //given
+        templateTwoRepository.save(templateTwo);
+        em.flush();
+        em.clear();
+        TemplateTwo templateTwo = templateTwoRepository.findById(this.templateTwo.getId()).orElseThrow(NullPointerException::new);
+        templateTwo.getProjects().forEach(project-> System.out.println("project = " + project.getName()));
     }
 }

--- a/appeal-api/src/test/resources/application.yml
+++ b/appeal-api/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        ddl-auto: none
+        format_sql: true
+
+logging:
+  level:
+    p6spy: info


### PR DESCRIPTION
1. TemplateTwo에 대한 id로 읽기 추가
- template를 가져올 때 portfolio는 fetch join으로 가져온다
- 나머지 두 컬렉션은(project, career) 두번의 추가 조인 쿼리로 컬렉션을 자동으로 채운다

2. Portfolio를 생성할 때 세션에서 Member를 가져오는 객체 변경
기존 : Portfolio
변경 : TemplateTwoService

도메인에서 직접 세션을 가져오면 service나 dto는 깨끗해지는 장점이 있다
반면 도메인은 security의 기술에 의존하게 되고 결국 이는 단위테스트에서 약점이 드러났다.
일단 애매한 기능은 전부 service로 옮기는 정책으로 간다.
security의 기술은 서비스에서 사용한다.