### PR TITLE
2021-03-05

### DIFF
--- a/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
+++ b/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.appeal.api.advice;
 
 import com.appeal.api.advice.dto.ErrorResponse;
 import com.appeal.exception.*;
+import com.appeal.exception.notfound.NotFoundException;
+import com.appeal.exception.notfound.NotFoundPortfolioException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -55,8 +57,8 @@ public class GlobalExceptionHandler {
                 ;
     }
 
-    @ExceptionHandler(NoPortfolioFoundException.class)
-    public ResponseEntity<ErrorResponse> noPortfolioFoundExceptoin(NoPortfolioFoundException exception){
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> NotFoundException(NotFoundException exception){
         ErrorResponse body = new ErrorResponse((exception.getMessage()));
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/appeal-api/src/main/java/com/appeal/api/member/controller/MemberController.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.appeal.api.member.controller;
 
-import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.member.dto.SignUpDto;
+import com.appeal.api.member.dto.UpdateMemberDto;
 import com.appeal.api.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -8,13 +9,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
-@RestController
 @RequiredArgsConstructor
+@RestController
+@RequestMapping("/member")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/signup")
+    @PostMapping
     public ResponseEntity signUp(@Valid @RequestBody SignUpDto dto){
         memberService.signUp(dto);
         return ResponseEntity
@@ -22,11 +24,26 @@ public class MemberController {
                 .body("you can signin after email validation");
     }
 
-    @GetMapping("/signup/{code}")
+    @GetMapping("/{code}")
     public ResponseEntity vaildSignUp(@PathVariable("code") String code){
         memberService.validSignUp(code);
         return ResponseEntity
                 .ok()
                 .body("인증 성공! 로그인하세용");
     }
+
+    /**
+     * @PathVariable은 애당초 URL패턴에 해당해서 @NotBlank를 붙일 필요가 없다
+     * id값이 없는 요청이 온다면 서블릿이 에러를 뱉을 것이다
+     * 이 경우에는 405 method not found를 뱉을 것이다
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity updateMemberInfo(@PathVariable("id") Long id,
+                                           @Valid @RequestBody UpdateMemberDto dto){
+        memberService.updateMemberInfo(id, dto);
+        return ResponseEntity
+                .ok()
+                .body("변경이 완료되었습니다!");
+    }
+
 }

--- a/appeal-api/src/main/java/com/appeal/api/member/domain/Member.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/domain/Member.java
@@ -2,7 +2,8 @@ package com.appeal.api.member.domain;
 
 import com.appeal.api.common.Authority;
 import com.appeal.api.common.BaseTimeInfo;
-import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.member.dto.SignUpDto;
+import com.appeal.api.member.dto.UpdateMemberDto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,5 +44,10 @@ public class Member extends BaseTimeInfo implements Serializable {
 
     public void successEmailValid() {
         authority = Authority.ROLE_USER;
+    }
+
+    public void updateInfo(UpdateMemberDto dto) {
+        password = dto.getPassword();
+        name = dto.getName();
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/member/dto/SignUpDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/dto/SignUpDto.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto;
+package com.appeal.api.member.dto;
 
 import lombok.*;
 

--- a/appeal-api/src/main/java/com/appeal/api/member/dto/UpdateMemberDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/dto/UpdateMemberDto.java
@@ -1,0 +1,14 @@
+package com.appeal.api.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter @Setter
+public class UpdateMemberDto {
+    @NotBlank
+    private String password;
+    @NotBlank
+    private String name;
+}

--- a/appeal-api/src/main/java/com/appeal/api/member/service/MemberService.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/service/MemberService.java
@@ -1,11 +1,12 @@
 package com.appeal.api.member.service;
 
-import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.member.dto.SignUpDto;
+import com.appeal.api.member.dto.UpdateMemberDto;
 import com.appeal.exception.DuplicateEmailException;
 import com.appeal.exception.IllegalEmailValidAccessExcetion;
-import com.appeal.exception.NoUserFoundException;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.repository.MemberRepository;
+import com.appeal.exception.notfound.NotFoundMemberException;
 import com.appeal.service.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -33,22 +34,31 @@ public class MemberService {
         redisTemplate.opsForValue().set(code, Long.toString(member.getId()));
     }
 
+    private void validDuplicateEmail(SignUpDto dto) {
+        memberRepository
+                .findByEmail(dto.getEmail())
+                .ifPresent(member -> {
+                    throw new DuplicateEmailException(dto.getEmail()+"은(는) 이미 등록된 이메일입니당");
+                });
+    }
+
+
     public void validSignUp(String code) {
         String memberId = Optional.ofNullable(redisTemplate.opsForValue().get(code))
                 .orElseThrow(() -> new IllegalEmailValidAccessExcetion());
 
         memberRepository
                 .findById(Long.parseLong(memberId))
-                .orElseThrow(()->new NoUserFoundException())
+                .orElseThrow(()->new NotFoundMemberException("등록하지 않은 멤버입니다!"))
                 .successEmailValid();
     }
 
-    private void validDuplicateEmail(SignUpDto dto) {
-        memberRepository
-                .findByEmail(dto.getEmail())
-                .ifPresent(user->{
-                    throw new DuplicateEmailException(dto.getEmail()+"은(는) 이미 등록된 이메일입니당");
+    public void updateMemberInfo(Long id, UpdateMemberDto dto) {
+        Member member = memberRepository
+                .findById(id)
+                .orElseThrow(() -> {
+                    throw new NotFoundMemberException("등록되지 않은 멤버입니다!");
                 });
+        member.updateInfo(dto);
     }
-
 }

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateTwoService.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/service/TemplateTwoService.java
@@ -6,7 +6,7 @@ import com.appeal.api.portfolio.dto.TemplateTwoFileDto;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.portfolio.domain.TemplateTwo;
 import com.appeal.api.portfolio.repository.TemplateTwoRepository;
-import com.appeal.exception.NoPortfolioFoundException;
+import com.appeal.exception.notfound.NotFoundPortfolioException;
 import com.appeal.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,7 +37,8 @@ public class TemplateTwoService implements TemplateService{
 
     @Override
     public TemplateDto getTemplateById(Long id) {
-        TemplateTwo templateTwo = templateTwoRepository.findById(id).orElseThrow(NoPortfolioFoundException::new);
+        TemplateTwo templateTwo = templateTwoRepository.findById(id)
+                .orElseThrow(()-> new  NotFoundPortfolioException("해당 포트폴리오는 없습니다"));
         return TemplateTwoDto.convertDomainToDto(templateTwo);
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/security/config/SecurityConfig.java
+++ b/appeal-api/src/main/java/com/appeal/api/security/config/SecurityConfig.java
@@ -21,6 +21,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
+import static org.springframework.http.HttpMethod.*;
+
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -38,8 +40,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
-                .antMatchers("/signup/**", "/signin").permitAll()
-                .antMatchers(HttpMethod.GET, "/template**/*", "/portfolio/**").permitAll()
+                .antMatchers(GET, "/member/**", "/template**/*", "/portfolio/**").permitAll()
+                .antMatchers(POST, "/member", "/signin").permitAll()
                 .antMatchers("/**").hasRole("USER")
                 .anyRequest().authenticated()
         ;

--- a/appeal-api/src/test/java/com/appeal/api/member/MemberControllerTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/MemberControllerTest.java
@@ -1,8 +1,9 @@
 package com.appeal.api.member;
 
 import com.appeal.api.advice.GlobalExceptionHandler;
-import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.member.dto.SignUpDto;
 import com.appeal.api.member.controller.MemberController;
+import com.appeal.api.member.dto.UpdateMemberDto;
 import com.appeal.api.member.service.MemberService;
 import com.appeal.api.security.handler.CustomAuthenticationFailureHandler;
 import com.appeal.api.security.handler.CustomAuthenticationSuccessHandler;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -33,23 +35,28 @@ class MemberControllerTest {
     @MockBean
     CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
 
-    SignUpDto dto;
+    String requestUrl = "/member";
+
+    SignUpDto signUpDto;
+    UpdateMemberDto updateMemberDto;
 
     @BeforeEach
     void before(){
-        dto = new SignUpDto("ma8511@naver.com", "1234", "youngwoo");
+        signUpDto = new SignUpDto("ma8511@naver.com", "1234", "youngwoo");
+        updateMemberDto = new UpdateMemberDto();
+        updateMemberDto.setName("hello");
+        updateMemberDto.setPassword("world");
     }
 
     @Test
     @DisplayName("정삭적인 요청")
     public void signUp() throws Exception{
         //given
-        String request = "/signup";
         //when
         //then
         MvcResult result = mvc.perform(
-                post(request)
-                        .content(asJsonString(dto))
+                post(requestUrl)
+                        .content(asJsonString(signUpDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
         )
@@ -63,14 +70,13 @@ class MemberControllerTest {
     @DisplayName("이메일 형식에 대한 테스트")
     public void emailFormatFail() throws Exception{
         //given
-        String request = "/signup";
-        dto.setEmail("noGoalBaeng2");
+        signUpDto.setEmail("noGoalBaeng2");
         //when
         //then
         mvc.perform(
-                post(request)
+                post(requestUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(asJsonString(dto))
+                .content(asJsonString(signUpDto))
                 .accept(MediaType.APPLICATION_JSON)
         )
         .andExpect(status().isBadRequest());
@@ -79,14 +85,13 @@ class MemberControllerTest {
     @DisplayName("비밀번호 공백")
     public void passwordBlank() throws Exception{
         //given
-        String request = "/signup";
-        dto.setPassword("");
+        signUpDto.setPassword("");
         //when
         //then
         mvc.perform(
-                post(request)
+                post(requestUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(dto))
+                        .content(asJsonString(signUpDto))
                         .accept(MediaType.APPLICATION_JSON)
         )
                 .andExpect(status().isBadRequest());
@@ -95,17 +100,32 @@ class MemberControllerTest {
     @DisplayName("이름공백")
     public void nameBlank() throws Exception{
         //given
-        String request = "/signup";
-        dto.setPassword("");
+        signUpDto.setPassword("");
         //when
         //then
         mvc.perform(
-                post(request)
+                post(requestUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(dto))
+                        .content(asJsonString(signUpDto))
                         .accept(MediaType.APPLICATION_JSON)
         )
                 .andExpect(status().isBadRequest());
+    }
+    @Test
+    @DisplayName("id를 넘기지 않은 요청")
+    @WithMockUser
+    public void idBlank() throws Exception{
+        //given
+        //when
+        mvc.perform(
+                put(requestUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(updateMemberDto))
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+                .andExpect(status().isMethodNotAllowed());
+
+        //then
     }
 
     public static String asJsonString(final Object obj){

--- a/appeal-api/src/test/java/com/appeal/api/member/MemberRepositoryTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/MemberRepositoryTest.java
@@ -1,10 +1,10 @@
 package com.appeal.api.member;
 
 import com.appeal.api.common.Authority;
-import com.appeal.api.common.dto.SignUpDto;
-import com.appeal.exception.NoUserFoundException;
+import com.appeal.api.member.dto.SignUpDto;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.repository.MemberRepository;
+import com.appeal.exception.notfound.NotFoundMemberException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,8 @@ class MemberRepositoryTest {
         memberRepository.save(member1);
 
         //when
-        Member member = memberRepository.findByEmail(member1.getEmail()).orElseThrow(NoUserFoundException::new);
+        Member member = memberRepository.findByEmail(member1.getEmail())
+                .orElseThrow(()-> new NotFoundMemberException("fjfj"));
 
         //then
         assertNotNull(member.getId());

--- a/appeal-api/src/test/java/com/appeal/api/member/dto/portfolio/TemplateTwoDtoTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/dto/portfolio/TemplateTwoDtoTest.java
@@ -1,4 +1,4 @@
-package com.appeal.api.common.dto.portfolio;
+package com.appeal.api.member.dto.portfolio;
 
 import com.appeal.api.portfolio.dto.PortfolioFileDto;
 import com.appeal.api.portfolio.dto.TemplateTwoDto;

--- a/appeal-api/src/test/java/com/appeal/api/member/service/MemberServiceTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/service/MemberServiceTest.java
@@ -1,0 +1,85 @@
+package com.appeal.api.member.service;
+
+import com.appeal.api.member.domain.Member;
+import com.appeal.api.member.dto.SignUpDto;
+import com.appeal.api.member.repository.MemberRepository;
+import com.appeal.exception.DuplicateEmailException;
+import com.appeal.exception.IllegalEmailValidAccessExcetion;
+import com.appeal.exception.notfound.NotFoundMemberException;
+import com.appeal.service.MailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MemberServiceTest {
+
+
+    MemberService memberService;
+    MemberRepository memberRepository;
+    MailService mailService;
+    PasswordEncoder passwordEncoder;
+    StringRedisTemplate redisTemplate;
+
+    SignUpDto dto;
+    final String DUPLICATE = "DUPLICATE";
+
+
+    @BeforeEach
+    void before(){
+        memberRepository = mock(MemberRepository.class);
+        mailService = mock(MailService.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        redisTemplate = mock(StringRedisTemplate.class);
+        memberService = new MemberService(memberRepository, mailService, passwordEncoder, redisTemplate);
+        dto = new SignUpDto();
+    }
+
+    @Test
+    @DisplayName("중복된 이메일 예외")
+    public void signUpFailbyDuplicate() throws Exception{
+        //given
+        dto.setEmail(DUPLICATE);
+        //when
+        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mock(Member.class)));
+        //then
+        assertThrows(DuplicateEmailException.class, ()->memberService.signUp(dto));
+    }
+
+    @Test
+    @DisplayName("레디스에서 코드에 맞는 멤버Id가 없는 경우")
+    public void redisDoesNotHaveId() throws Exception{
+        //given
+        String code = "somecode";
+        ValueOperations ops = mock(ValueOperations.class);
+        //when
+        when(redisTemplate.opsForValue()).thenReturn(ops);
+        when(ops.get(code)).thenReturn(null);
+        //then
+        assertThrows(IllegalEmailValidAccessExcetion.class, ()->memberService.validSignUp(code));
+    }
+
+    @Test
+    @DisplayName("레디스에서 얻은 아이디가 DB에 등록이 안돼 있는 경우")
+    public void fromRedisIdNotFoundDB() throws Exception{
+        //given
+        String code = "somecode";
+        String id = "1";
+        Long lid = 1L;
+        ValueOperations ops = mock(ValueOperations.class);
+        //when
+        when(redisTemplate.opsForValue()).thenReturn(ops);
+        when(ops.get(code)).thenReturn(id);
+        when(memberRepository.findById(lid)).thenReturn(Optional.empty());
+        //then
+        assertThrows(NotFoundMemberException.class, ()->memberService.validSignUp(code));
+    }
+
+}

--- a/appeal-api/src/test/java/com/appeal/api/portfolio/repository/TemplateTwoRepositoryTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/portfolio/repository/TemplateTwoRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.appeal.api.portfolio.repository;
 
-import com.appeal.api.common.dto.SignUpDto;
+import com.appeal.api.member.dto.SignUpDto;
 import com.appeal.api.portfolio.dto.PortfolioDto;
 import com.appeal.api.portfolio.dto.TemplateTwoCareerDto;
 import com.appeal.api.portfolio.dto.TemplateTwoDto;

--- a/appeal-common/src/main/java/com/appeal/exception/NoPortfolioFoundException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NoPortfolioFoundException.java
@@ -1,4 +1,0 @@
-package com.appeal.exception;
-
-public class NoPortfolioFoundException extends RuntimeException {
-}

--- a/appeal-common/src/main/java/com/appeal/exception/NoUserFoundException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NoUserFoundException.java
@@ -1,4 +1,0 @@
-package com.appeal.exception;
-
-public class NoUserFoundException extends RuntimeException {
-}

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception.notfound;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundMemberException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundMemberException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception.notfound;
+
+public class NotFoundMemberException extends NotFoundException {
+    public NotFoundMemberException(String message) {
+        super(message);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundPortfolioException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundPortfolioException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception.notfound;
+
+public class NotFoundPortfolioException extends NotFoundException {
+    public NotFoundPortfolioException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
업데이트 사항
1. 멤버 업데이트 추가
2. 멤버관련 URL매칭 전부 /member로 통일 및 메소드로 구분
3. 테슽트 코드 꾸준히 추가 중 ^^

해야할 일
1. 인증 성공 후 멤버Id를 응답에 반환해줘야 모든 로직 처리 가능
2. 멤버 삭제까지 간단하게 만든 후 MEMBER CRUD 완성하기
3. 레디스를 이용해 인증코드를 관리하는데 opsForValue()를 호출할 때 테스트가 2중 모킹해야됨 구린내 풀풀