### PR TITLE
2021-04-05

### DIFF
--- a/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
+++ b/appeal-api/src/main/java/com/appeal/api/advice/GlobalExceptionHandler.java
@@ -1,68 +1,21 @@
 package com.appeal.api.advice;
 
 import com.appeal.api.advice.dto.ErrorResponse;
-import com.appeal.exception.*;
-import com.appeal.exception.notfound.NotFoundException;
-import com.appeal.exception.notfound.NotFoundPortfolioException;
-import lombok.extern.slf4j.Slf4j;
+import com.appeal.exception.BusinessException;
+import com.appeal.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-@Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(DuplicateEmailException.class)
-    public ResponseEntity<ErrorResponse> duplicateEmailExceptionHandler(DuplicateEmailException exception) {
-        ErrorResponse body = new ErrorResponse(exception.getMessage());
-        log.info("DuplicatException : {}", exception.getMessage());
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(body);
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e){
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
     }
 
-    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
-    protected ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException exception){
-        ErrorResponse body = new ErrorResponse(exception.getMessage());
-        log.info("Method Arg 이상해 : {}", exception.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(body);
-    }
-
-    @ExceptionHandler(FailImageUploadException.class)
-    public ResponseEntity<ErrorResponse> failImageUploadExceptionHandler(FailImageUploadException exception){
-        ErrorResponse body = new ErrorResponse(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
-                .body(body);
-    }
-
-    @ExceptionHandler(NoSupportDtoException.class)
-    public ResponseEntity<ErrorResponse> noSupportDtoException(NoSupportDtoException exception){
-        ErrorResponse body = new ErrorResponse(exception.getMessage());
-        log.info("더이상 지원하지 않는 dto입니다");
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(body)
-                ;
-    }
-
-    @ExceptionHandler(UnexpectedMethodArgumentNullPointerException.class)
-    public ResponseEntity<ErrorResponse> unexpectedMethodArgumentNullPointerException(UnexpectedMethodArgumentNullPointerException exception){
-        ErrorResponse body = new ErrorResponse(exception.getMessage());
-        log.info("나올 수 없는 널포인터 익셉션: {}", exception.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(body)
-                ;
-    }
-
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ErrorResponse> NotFoundException(NotFoundException exception){
-        ErrorResponse body = new ErrorResponse((exception.getMessage()));
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(body)
-                ;
-    }
 }

--- a/appeal-api/src/main/java/com/appeal/api/advice/dto/ErrorResponse.java
+++ b/appeal-api/src/main/java/com/appeal/api/advice/dto/ErrorResponse.java
@@ -1,11 +1,33 @@
 package com.appeal.api.advice.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import com.appeal.exception.ErrorCode;
 import lombok.Getter;
 
-@AllArgsConstructor(access = AccessLevel.PUBLIC)
+
 @Getter
 public class ErrorResponse {
-    private String message;
+    private final String message;
+    private final int status;
+    private final String code;
+
+//    private List<FieldError> errors;
+
+
+    private ErrorResponse(String message, int status, String code) {
+        this.message = message;
+        this.status = status;
+        this.code = code;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getMessage(), errorCode.getStatus(), errorCode.getCode());
+    }
+
+    /*
+    public static class FieldError{
+        private String field;
+        private String value;
+        private String code;
+    }
+     */
 }

--- a/appeal-api/src/main/java/com/appeal/api/member/service/MemberService.java
+++ b/appeal-api/src/main/java/com/appeal/api/member/service/MemberService.java
@@ -4,10 +4,11 @@ import com.appeal.api.member.dto.MemberSession;
 import com.appeal.api.member.dto.MemberDto;
 import com.appeal.api.member.dto.UpdateMemberDto;
 import com.appeal.exception.DuplicateEmailException;
-import com.appeal.exception.IllegalEmailValidAccessExcetion;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.FailValidEmailExcetion;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.repository.MemberRepository;
-import com.appeal.exception.notfound.NotFoundMemberException;
+import com.appeal.exception.NotFoundMemberException;
 import com.appeal.service.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -39,18 +40,18 @@ public class MemberService {
         memberRepository
                 .findByEmail(dto.getEmail())
                 .ifPresent(member -> {
-                    throw new DuplicateEmailException(dto.getEmail()+"은(는) 이미 등록된 이메일입니당");
+                    throw new DuplicateEmailException(ErrorCode.DUPLICATE_EMAIL);
                 });
     }
 
 
     public void validSignUp(String code) {
         String memberId = Optional.ofNullable(redisTemplate.opsForValue().get(code))
-                .orElseThrow(() -> new IllegalEmailValidAccessExcetion());
+                .orElseThrow(() -> new FailValidEmailExcetion(ErrorCode.FAIL_VALID_EMAIL));
 
         memberRepository
                 .findById(Long.parseLong(memberId))
-                .orElseThrow(()->new NotFoundMemberException("등록하지 않은 멤버입니다!"))
+                .orElseThrow(()->new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER))
                 .successEmailValid();
     }
 
@@ -58,7 +59,7 @@ public class MemberService {
         Member member = memberRepository
                 .findById(memberSession.getId())
                 .orElseThrow(() -> {
-                    throw new NotFoundMemberException("등록되지 않은 멤버입니다!");
+                    throw new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER);
                 });
         member.updateInfo(dto);
     }

--- a/appeal-api/src/main/java/com/appeal/api/portfolio/service/PortfolioService.java
+++ b/appeal-api/src/main/java/com/appeal/api/portfolio/service/PortfolioService.java
@@ -6,7 +6,8 @@ import com.appeal.api.member.repository.MemberRepository;
 import com.appeal.api.portfolio.domain.Portfolio;
 import com.appeal.api.portfolio.dto.PortfolioDto;
 import com.appeal.api.portfolio.repository.PortfolioRepository;
-import com.appeal.exception.notfound.NotFoundMemberException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +23,7 @@ public class PortfolioService {
 
     public List<PortfolioDto> getBySession(MemberSession session){
         Member member = memberRepository.findById(session.getId())
-                .orElseThrow(() -> new NotFoundMemberException("nonono"));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         List<PortfolioDto> dtos = new ArrayList<>();
         portfolios.forEach(portfolio -> {

--- a/appeal-api/src/main/java/com/appeal/api/security/config/Config.java
+++ b/appeal-api/src/main/java/com/appeal/api/security/config/Config.java
@@ -50,8 +50,6 @@ public class Config {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.addAllowedOriginPattern("*");
-//        configuration.addAllowedOrigin("http://www.appeal.icu");
-//        configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);

--- a/appeal-api/src/main/java/com/appeal/api/security/handler/CustomAuthenticationFailureHandler.java
+++ b/appeal-api/src/main/java/com/appeal/api/security/handler/CustomAuthenticationFailureHandler.java
@@ -1,5 +1,6 @@
 package com.appeal.api.security.handler;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -14,5 +15,6 @@ public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationF
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/security/provider/CustomAuthenticationProvider.java
+++ b/appeal-api/src/main/java/com/appeal/api/security/provider/CustomAuthenticationProvider.java
@@ -1,7 +1,7 @@
 package com.appeal.api.security.provider;
 
 import com.appeal.api.common.Authority;
-import com.appeal.exception.NoValidAccountException;
+import com.appeal.exception.NotValidAccountException;
 import com.appeal.api.security.sevice.MemberContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -31,7 +31,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         SimpleGrantedAuthority rolePre = new SimpleGrantedAuthority(Authority.ROLE_PRE.name());
         if(memberContext.getAuthorities().contains(rolePre))
-            throw new NoValidAccountException("미인증 계정입니다");
+            throw new NotValidAccountException("미인증 계정입니다");
 
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(

--- a/appeal-api/src/main/java/com/appeal/api/template/dto/templatetwo/TemplateTwoDto.java
+++ b/appeal-api/src/main/java/com/appeal/api/template/dto/templatetwo/TemplateTwoDto.java
@@ -6,6 +6,7 @@ import com.appeal.api.template.domain.templatetwo.TemplateTwoCareer;
 import com.appeal.api.template.domain.templatetwo.TemplateTwoProject;
 import com.appeal.api.portfolio.dto.PortfolioDto;
 import com.appeal.api.template.dto.TemplateDto;
+import com.appeal.exception.ErrorCode;
 import com.appeal.exception.UnexpectedMethodArgumentNullPointerException;
 import com.appeal.service.AwsS3Service;
 import lombok.AccessLevel;
@@ -30,7 +31,7 @@ public class TemplateTwoDto implements TemplateDto {
             templateTwoDto.convertProjectFileDtotoStringUrlDto(dto, s3Service);
             templateTwoDto.careers = dto.getCareers();  // can null
         }catch (NullPointerException e){
-            throw new UnexpectedMethodArgumentNullPointerException("Null이 나올 수 없는 상황입니다");
+            throw new UnexpectedMethodArgumentNullPointerException(ErrorCode.UNEXPECTED_METHOD_ARGUMENT_NULLPOINTER);
         }
         return templateTwoDto;
     }

--- a/appeal-api/src/main/java/com/appeal/api/template/service/TemplateOneService.java
+++ b/appeal-api/src/main/java/com/appeal/api/template/service/TemplateOneService.java
@@ -4,19 +4,17 @@ import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.dto.MemberSession;
 import com.appeal.api.member.repository.MemberRepository;
 import com.appeal.api.template.domain.templateone.TemplateOne;
-import com.appeal.api.template.domain.templatetwo.TemplateTwo;
 import com.appeal.api.template.dto.TemplateDto;
 import com.appeal.api.template.dto.templateone.TemplateOneDto;
 import com.appeal.api.template.dto.templateone.TemplateOneFileDto;
 import com.appeal.api.template.repository.TemplateOneRepository;
-import com.appeal.exception.NoAuthorizationException;
-import com.appeal.exception.notfound.NotFoundMemberException;
-import com.appeal.exception.notfound.NotFoundPortfolioException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.NotAuthorizationException;
+import com.appeal.exception.NotFoundMemberException;
+import com.appeal.exception.NotFoundPortfolioException;
 import com.appeal.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class TemplateOneService implements TemplateService{
     @Override
     public Long createTemplate(MemberSession session, TemplateDto dto) {
         Member member = memberRepository.findById(session.getId())
-                .orElseThrow(() -> new NotFoundMemberException("없는 유저입니다"));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
 
         TemplateOneDto templateOneDto = TemplateOneDto.convertFileDtoToStringUrl((TemplateOneFileDto) dto, s3Service);
         TemplateOne templateOne = TemplateOne.createTemplateOne(templateOneDto, member);
@@ -40,19 +38,19 @@ public class TemplateOneService implements TemplateService{
     @Override
     public TemplateDto getTemplateById(Long id) {
         TemplateOne templateOne = templateOneRepository.findById(id)
-                .orElseThrow(()-> new NotFoundPortfolioException("해당 포트폴리오는 없습니다"));
+                .orElseThrow(()-> new NotFoundPortfolioException(ErrorCode.NOT_FOUND_PORTFOLIO));
         return TemplateOneDto.convertDomainToDto(templateOne);
     }
 
     @Override
     public void deleteTemplate(MemberSession session, Long id) {
         Member member = memberRepository.findById(session.getId())
-                .orElseThrow(() -> new NotFoundMemberException("없는 유저입니다"));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
         TemplateOne templateOne = templateOneRepository.findById(id)
-                .orElseThrow(()-> new NotFoundPortfolioException("해당 포트폴리오는 없습니다"));
+                .orElseThrow(()-> new NotFoundPortfolioException(ErrorCode.NOT_FOUND_PORTFOLIO));
 
         if(templateOne.getPortfolio().getMember() != member)
-            throw new NoAuthorizationException("삭제 권한이 없습니다");
+            throw new NotAuthorizationException(ErrorCode.NOT_AUTHORIZATION);
         templateOneRepository.delete(templateOne);
     }
 }

--- a/appeal-api/src/main/java/com/appeal/api/template/service/TemplateTwoService.java
+++ b/appeal-api/src/main/java/com/appeal/api/template/service/TemplateTwoService.java
@@ -8,9 +8,10 @@ import com.appeal.api.template.dto.templatetwo.TemplateTwoFileDto;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.template.domain.templatetwo.TemplateTwo;
 import com.appeal.api.template.repository.TemplateTwoRepository;
-import com.appeal.exception.NoAuthorizationException;
-import com.appeal.exception.notfound.NotFoundMemberException;
-import com.appeal.exception.notfound.NotFoundPortfolioException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.NotAuthorizationException;
+import com.appeal.exception.NotFoundMemberException;
+import com.appeal.exception.NotFoundPortfolioException;
 import com.appeal.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class TemplateTwoService implements TemplateService{
     @Override
     public Long createTemplate(MemberSession session, TemplateDto dto) {
         Member member = memberRepository.findById(session.getId())
-                .orElseThrow(() -> new NotFoundMemberException("없는 유저입니다"));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
 
         TemplateTwoDto templateTwoDto = TemplateTwoDto.convertFileDtoToStringUrl((TemplateTwoFileDto) dto, s3Service);
         TemplateTwo templateTwo = TemplateTwo.createTemplateTwo(templateTwoDto, member);
@@ -40,7 +41,7 @@ public class TemplateTwoService implements TemplateService{
     @Override
     public TemplateDto getTemplateById(Long id) {
         TemplateTwo templateTwo = templateTwoRepository.findById(id)
-                .orElseThrow(()-> new  NotFoundPortfolioException("해당 포트폴리오는 없습니다"));
+                .orElseThrow(()-> new  NotFoundPortfolioException(ErrorCode.NOT_FOUND_PORTFOLIO));
         return TemplateTwoDto.convertDomainToDto(templateTwo);
     }
 
@@ -56,12 +57,12 @@ public class TemplateTwoService implements TemplateService{
     @Override
     public void deleteTemplate(MemberSession session, Long id) {
         Member member = memberRepository.findById(session.getId())
-                .orElseThrow(() -> new NotFoundMemberException("없는 유저입니다"));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
         TemplateTwo templateTwo = templateTwoRepository.findById(id)
-                .orElseThrow(()-> new  NotFoundPortfolioException("해당 포트폴리오는 없습니다"));
+                .orElseThrow(()-> new  NotFoundPortfolioException(ErrorCode.NOT_FOUND_PORTFOLIO));
 
         if(member != templateTwo.getPortfolio().getMember())
-            throw new NoAuthorizationException("삭제 권한이 없습니다");
+            throw new NotAuthorizationException(ErrorCode.NOT_AUTHORIZATION);
         templateTwoRepository.delete(templateTwo);
     }
 }

--- a/appeal-api/src/test/java/com/appeal/api/member/MemberRepositoryTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/MemberRepositoryTest.java
@@ -4,7 +4,8 @@ import com.appeal.api.common.Authority;
 import com.appeal.api.member.dto.MemberDto;
 import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.repository.MemberRepository;
-import com.appeal.exception.notfound.NotFoundMemberException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.NotFoundMemberException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class MemberRepositoryTest {
 
         //when
         Member member = memberRepository.findByEmail(member1.getEmail())
-                .orElseThrow(()-> new NotFoundMemberException("fjfj"));
+                .orElseThrow(()-> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER));
 
         //then
         assertNotNull(member.getId());

--- a/appeal-api/src/test/java/com/appeal/api/member/service/MemberServiceTest.java
+++ b/appeal-api/src/test/java/com/appeal/api/member/service/MemberServiceTest.java
@@ -4,8 +4,8 @@ import com.appeal.api.member.domain.Member;
 import com.appeal.api.member.dto.MemberDto;
 import com.appeal.api.member.repository.MemberRepository;
 import com.appeal.exception.DuplicateEmailException;
-import com.appeal.exception.IllegalEmailValidAccessExcetion;
-import com.appeal.exception.notfound.NotFoundMemberException;
+import com.appeal.exception.FailValidEmailExcetion;
+import com.appeal.exception.NotFoundMemberException;
 import com.appeal.service.MailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +63,7 @@ class MemberServiceTest {
         when(redisTemplate.opsForValue()).thenReturn(ops);
         when(ops.get(code)).thenReturn(null);
         //then
-        assertThrows(IllegalEmailValidAccessExcetion.class, ()->memberService.validSignUp(code));
+        assertThrows(FailValidEmailExcetion.class, ()->memberService.validSignUp(code));
     }
 
     @Test

--- a/appeal-aws-s3/src/main/java/com/appeal/service/AwsS3Service.java
+++ b/appeal-aws-s3/src/main/java/com/appeal/service/AwsS3Service.java
@@ -7,7 +7,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.appeal.exception.FailImageUploadException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.FailUploadImageException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -51,7 +52,7 @@ public class AwsS3Service {
             s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         }catch (IOException e){
-            throw new FailImageUploadException("이미지업로드에 실패했습니다!");
+            throw new FailUploadImageException(ErrorCode.FAIL_UPLOAD_IMAGE);
         }catch (NullPointerException e){
             return null;
         }

--- a/appeal-common/src/main/java/com/appeal/exception/BusinessException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.appeal.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/DuplicateEmailException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/DuplicateEmailException.java
@@ -1,7 +1,8 @@
 package com.appeal.exception;
 
-public class DuplicateEmailException extends RuntimeException{
-    public DuplicateEmailException(String message) {
-        super(message);
+public class DuplicateEmailException extends BusinessException{
+
+    public DuplicateEmailException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/appeal-common/src/main/java/com/appeal/exception/ErrorCode.java
+++ b/appeal-common/src/main/java/com/appeal/exception/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.appeal.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public enum ErrorCode {
+    /**
+    - 형식 : (부정형)?(동사)(대상)+
+     */
+
+    // common
+    NOT_AUTHORIZATION("C001", "자원에 접근 권한이 없습니다", 403),
+    NOT_SUPPORT_DTO("C002", "지원하지 않는 입력 형식입니다", 400),
+    UNEXPECTED_METHOD_ARGUMENT_NULLPOINTER("C003", "말도 안되게 NULL이 나왔습니다 확인 요망", 500),
+    FAIL_SEND_EMAIL("C004", "이메일 전송에 실패했습니다. 메일서버 확인!", 500),
+
+    // member
+    NOT_FOUND_MEMBER("M001", "등록되지 않은 멤버입니다!", 400),
+    DUPLICATE_EMAIL("M002", "이미 등록한 이메일입니다", 409),
+    FAIL_VALID_EMAIL("M003", "인증코드 접근이 올바르지 않습니다", 400),
+    NOT_VALID_ACCOUNT("M004", "이메일 인증이 완료되지 않았습니다", 400),
+
+    // portfolio
+    NOT_FOUND_PORTFOLIO("P001", "등록되지 않은 포트폴리오입니다!", 400),
+    FAIL_UPLOAD_IMAGE("P002", "이미지 업로드에 실패했습니다!", 502),
+
+    ;
+    private final String code;
+    private final String message;
+    private final int status;
+
+}

--- a/appeal-common/src/main/java/com/appeal/exception/FailImageUploadException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/FailImageUploadException.java
@@ -1,7 +1,0 @@
-package com.appeal.exception;
-
-public class FailImageUploadException extends RuntimeException{
-    public FailImageUploadException(String message) {
-        super(message);
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/FailSendMailException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/FailSendMailException.java
@@ -1,0 +1,8 @@
+package com.appeal.exception;
+
+public class FailSendMailException extends BusinessException {
+
+    public FailSendMailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/FailUploadImageException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/FailUploadImageException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception;
+
+public class FailUploadImageException extends BusinessException{
+    public FailUploadImageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/FailValidEmailExcetion.java
+++ b/appeal-common/src/main/java/com/appeal/exception/FailValidEmailExcetion.java
@@ -1,0 +1,7 @@
+package com.appeal.exception;
+
+public class FailValidEmailExcetion extends BusinessException {
+    public FailValidEmailExcetion(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/IllegalEmailValidAccessExcetion.java
+++ b/appeal-common/src/main/java/com/appeal/exception/IllegalEmailValidAccessExcetion.java
@@ -1,4 +1,0 @@
-package com.appeal.exception;
-
-public class IllegalEmailValidAccessExcetion extends RuntimeException {
-}

--- a/appeal-common/src/main/java/com/appeal/exception/NoAuthorizationException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NoAuthorizationException.java
@@ -1,6 +1,0 @@
-package com.appeal.exception;
-
-public class NoAuthorizationException extends RuntimeException {
-    public NoAuthorizationException(String message) {
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/NoSupportDtoException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NoSupportDtoException.java
@@ -1,6 +1,0 @@
-package com.appeal.exception;
-
-public class NoSupportDtoException extends RuntimeException {
-    public NoSupportDtoException(String s) {
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/NotAuthorizationException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NotAuthorizationException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception;
+
+public class NotAuthorizationException extends BusinessException {
+    public NotAuthorizationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/NotFoundMemberException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NotFoundMemberException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception;
+
+public class NotFoundMemberException extends BusinessException {
+    public NotFoundMemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/NotFoundPortfolioException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NotFoundPortfolioException.java
@@ -1,0 +1,8 @@
+package com.appeal.exception;
+
+public class NotFoundPortfolioException extends BusinessException {
+
+    public NotFoundPortfolioException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/NotSupportDtoException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NotSupportDtoException.java
@@ -1,0 +1,7 @@
+package com.appeal.exception;
+
+public class NotSupportDtoException extends BusinessException {
+    public NotSupportDtoException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/appeal-common/src/main/java/com/appeal/exception/NotValidAccountException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/NotValidAccountException.java
@@ -2,8 +2,8 @@ package com.appeal.exception;
 
 import org.springframework.security.core.AuthenticationException;
 
-public class NoValidAccountException extends AuthenticationException {
-    public NoValidAccountException(String msg) {
+public class NotValidAccountException extends AuthenticationException {
+    public NotValidAccountException(String msg) {
         super(msg);
     }
 }

--- a/appeal-common/src/main/java/com/appeal/exception/SendMailFailureException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/SendMailFailureException.java
@@ -1,7 +1,0 @@
-package com.appeal.exception;
-
-public class SendMailFailureException extends RuntimeException {
-    public SendMailFailureException(String message) {
-        super(message);
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/UnexpectedMethodArgumentNullPointerException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/UnexpectedMethodArgumentNullPointerException.java
@@ -1,6 +1,7 @@
 package com.appeal.exception;
 
-public class UnexpectedMethodArgumentNullPointerException extends RuntimeException {
-    public UnexpectedMethodArgumentNullPointerException(String message) {
+public class UnexpectedMethodArgumentNullPointerException extends BusinessException {
+    public UnexpectedMethodArgumentNullPointerException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundException.java
@@ -1,7 +1,0 @@
-package com.appeal.exception.notfound;
-
-public class NotFoundException extends RuntimeException{
-    public NotFoundException(String message) {
-        super(message);
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundMemberException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundMemberException.java
@@ -1,7 +1,0 @@
-package com.appeal.exception.notfound;
-
-public class NotFoundMemberException extends NotFoundException {
-    public NotFoundMemberException(String message) {
-        super(message);
-    }
-}

--- a/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundPortfolioException.java
+++ b/appeal-common/src/main/java/com/appeal/exception/notfound/NotFoundPortfolioException.java
@@ -1,7 +1,0 @@
-package com.appeal.exception.notfound;
-
-public class NotFoundPortfolioException extends NotFoundException {
-    public NotFoundPortfolioException(String message) {
-        super(message);
-    }
-}

--- a/appeal-mail/src/main/java/com/appeal/service/MailService.java
+++ b/appeal-mail/src/main/java/com/appeal/service/MailService.java
@@ -1,6 +1,7 @@
 package com.appeal.service;
 
-import com.appeal.exception.SendMailFailureException;
+import com.appeal.exception.ErrorCode;
+import com.appeal.exception.FailSendMailException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -32,7 +33,7 @@ public class MailService {
             mailSender.send(message);
             return code;
         } catch (MessagingException e) {
-            throw new SendMailFailureException("인증메일 전송에 실패하였습니다");
+            throw new FailSendMailException(ErrorCode.FAIL_SEND_EMAIL);
         }
     }
 


### PR DESCRIPTION
변경 사항
- 예외처리를 추상화한 BusinessException으로 깔끔하게 처리
- ResponseEntity<> 의미 이해 : HttpEntity에 status를 추가함으로써 상태코드 자유로이 설정 가능
- ErrorResponse에 예외의 데이터를 넣을 수 있도록 설정
- 그에 맞에 ErrorCode enum타입으로 설정